### PR TITLE
Remove dependency on github.com/writeas/nerds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/writeas/impart v1.1.0
-	github.com/writeas/nerds v1.0.0
 	github.com/writeas/openssl-go v1.0.0
 	github.com/writeas/saturday v1.6.0
 	golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5I
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/writeas/impart v1.1.0 h1:nPnoO211VscNkp/gnzir5UwCDEvdHThL5uELU60NFSE=
 github.com/writeas/impart v1.1.0/go.mod h1:g0MpxdnTOHHrl+Ca/2oMXUHJ0PcRAEWtkCzYCJUXC9Y=
-github.com/writeas/nerds v1.0.0 h1:ZzRcCN+Sr3MWID7o/x1cr1ZbLvdpej9Y1/Ho+JKlqxo=
-github.com/writeas/nerds v1.0.0/go.mod h1:Gn2bHy1EwRcpXeB7ZhVmuUwiweK0e+JllNf66gvNLdU=
 github.com/writeas/openssl-go v1.0.0 h1:YXM1tDXeYOlTyJjoMlYLQH1xOloUimSR1WMF8kjFc5o=
 github.com/writeas/openssl-go v1.0.0/go.mod h1:WsKeK5jYl0B5y8ggOmtVjbmb+3rEGqSD25TppjJnETA=
 github.com/writeas/saturday v1.6.0 h1:HNUtX8TVJJnSdxE8vaAgtHiAJVt+Of5AJYlm62pmVlI=

--- a/id/random.go
+++ b/id/random.go
@@ -2,11 +2,25 @@ package id
 
 import (
 	"fmt"
-	"github.com/writeas/nerds/store"
+	"crypto/rand"
 )
+
+// GenerateRandomString creates a random string of characters of the given
+// length from the given dictionary of possible characters.
+//
+// This example generates a hexadecimal string 6 characters long:
+//     GenerateRandomString("0123456789abcdef", 6)
+func GenerateRandomString(dictionary string, l int) string {
+	var bytes = make([]byte, l)
+	rand.Read(bytes)
+	for k, v := range bytes {
+		bytes[k] = dictionary[v%byte(len(dictionary))]
+	}
+	return string(bytes)
+}
 
 // GenSafeUniqueSlug generatees a reasonably unique random slug from the given
 // original slug. It's "safe" because it uses 0-9 b-z excluding vowels.
 func GenSafeUniqueSlug(slug string) string {
-	return fmt.Sprintf("%s-%s", slug, store.GenerateRandomString("0123456789bcdfghjklmnpqrstvwxyz", 4))
+	return fmt.Sprintf("%s-%s", slug, GenerateRandomString("0123456789bcdfghjklmnpqrstvwxyz", 4))
 }


### PR DESCRIPTION
Moves the `GenerateRandomString` function out of `github.com/writeas/nerds` and into `id/random.go`, thereby removing the dependency on the additional package.

Fixes issue #7.
 
All tests pass.