### PR TITLE
Add (forceful) Reset function to memo

### DIFF
--- a/memo/memo.go
+++ b/memo/memo.go
@@ -67,3 +67,12 @@ func (memo *Memo) Get() (value interface{}, err error) {
 	}
 	return memo.cache.res.value, memo.cache.res.err
 }
+
+// Reset forcibly resets the cache to nil.
+func (memo *Memo) Reset() {
+	defer memo.mu.Unlock()
+	memo.mu.Lock()
+
+	memo.cache = nil
+	memo.lastCache = time.Now()
+}

--- a/memo/memo.go
+++ b/memo/memo.go
@@ -68,7 +68,8 @@ func (memo *Memo) Get() (value interface{}, err error) {
 	return memo.cache.res.value, memo.cache.res.err
 }
 
-// Reset forcibly resets the cache to nil.
+// Reset forcibly resets the cache to nil without checking if the cache
+// duration has elapsed.
 func (memo *Memo) Reset() {
 	defer memo.mu.Unlock()
 	memo.mu.Lock()


### PR DESCRIPTION
Add a new function Reset to memo to forcibly reset the cache

[ref](https://github.com/writeas/writefreely/pull/384)